### PR TITLE
Bring back PaginateChoiceState for issue list.

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -16,6 +16,7 @@ go.app = function() {
     var FreeText = vumigo.states.FreeText;
     var JsonApi = vumigo.http.api.JsonApi;
     var ChoiceState = vumigo.states.ChoiceState;
+    var PaginatedChoiceState = vumigo.states.PaginatedChoiceState;
     var MetricsHelper = require('go-jsbox-metrics-helper');
     var Ona = require('go-jsbox-ona').Ona;
 
@@ -23,6 +24,7 @@ go.app = function() {
     var GoApp = App.extend(function(self) {
         App.call(self, 'states:detect-language');
         var $ = self.$;
+        var characters_per_page = 139;
 
         self.now = function() {
             var timestamp =
@@ -223,8 +225,10 @@ go.app = function() {
             });
             choices.push(new Choice('other', $('Other')));
 
-            return new ChoiceState(name, {
+            return new PaginatedChoiceState(name, {
                 question: $('What is the problem?'),
+                options_per_page: 6,
+                characters_per_page: characters_per_page,
                 choices: choices,
                 next: function(choice) {
                     return choice.value === 'other'

--- a/go-app.js
+++ b/go-app.js
@@ -227,7 +227,7 @@ go.app = function() {
 
             return new PaginatedChoiceState(name, {
                 question: $('What is the problem?'),
-                options_per_page: 6,
+                options_per_page: 7,
                 characters_per_page: characters_per_page,
                 choices: choices,
                 next: function(choice) {

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ go.app = function() {
     var FreeText = vumigo.states.FreeText;
     var JsonApi = vumigo.http.api.JsonApi;
     var ChoiceState = vumigo.states.ChoiceState;
+    var PaginatedChoiceState = vumigo.states.PaginatedChoiceState;
     var MetricsHelper = require('go-jsbox-metrics-helper');
     var Ona = require('go-jsbox-ona').Ona;
 
@@ -16,6 +17,7 @@ go.app = function() {
     var GoApp = App.extend(function(self) {
         App.call(self, 'states:detect-language');
         var $ = self.$;
+        var characters_per_page = 139;
 
         self.now = function() {
             var timestamp =
@@ -216,8 +218,10 @@ go.app = function() {
             });
             choices.push(new Choice('other', $('Other')));
 
-            return new ChoiceState(name, {
+            return new PaginatedChoiceState(name, {
                 question: $('What is the problem?'),
+                options_per_page: 6,
+                characters_per_page: characters_per_page,
                 choices: choices,
                 next: function(choice) {
                     return choice.value === 'other'

--- a/src/app.js
+++ b/src/app.js
@@ -220,7 +220,7 @@ go.app = function() {
 
             return new PaginatedChoiceState(name, {
                 question: $('What is the problem?'),
-                options_per_page: 6,
+                options_per_page: 7,
                 characters_per_page: characters_per_page,
                 choices: choices,
                 next: function(choice) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -270,9 +270,11 @@ describe("App", function() {
                               "xh": "Ikhathegori 5"
                             }
                         ],
-                        'query': 'MN31', 
+                        'query': 'MN31',
                         'toilet':{}},
-                    metadata: {},
+                    metadata: {
+                        "page_start": 0,
+                    },
                     name: 'states:report-issue'
                 })
                 .check.reply.char_limit()
@@ -396,7 +398,9 @@ describe("App", function() {
                           ],
                         'query': 'MN',
                         'toilet': {}},
-                    metadata: {},
+                    metadata: {
+                        page_start: 0,
+                    },
                     name: 'states:report-issue'
                 })
                 .run();
@@ -530,7 +534,9 @@ describe("App", function() {
                             "lon": -18.66404
                         },
                         query: "MN34"},
-                    metadata: {},
+                    metadata: {
+                        page_start: 0,
+                    },
                     name: 'states:report-issue'
                 })
                 .run();


### PR DESCRIPTION
But this time using `options_per_page` (set to 6) since that doesn't suffer from the length calculating bug that auto-pagination does. 
