### PR TITLE
Add basic support for adding tags to Snappy reports.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,13 @@ Config parameters:
         snappy.conversation         Snappy conversation to submit under
         snappy.auth_user            Authentication user for Snappy bouncer
         snappy.auth_token           Authentication token for Snappy bouncer
+        snappy.tags                 Tags to send to Snappy.
     ona:                            Ona information
         ona.id:                     Ona form identifier
         ona.username:               Ona auth username
         ona.password:               Ona auth password
         ona.url:                    URL for Ona API
-    clusten_len:                    Length of radius for cluster 
+    clusten_len:                    Length of radius for cluster
                                     (deterministic) circles
     issue_len:                      Length of radius for issue (random) circles
 

--- a/go-app.js
+++ b/go-app.js
@@ -304,12 +304,14 @@ go.app = function() {
                 code: data.toilet.code,
                 lat: data.toilet.lat,
                 lon: data.toilet.lon,
-                issue: data.issue.value
+                issue: data.issue.value,
+                tags: snappy_conf.tags,
             }, {
                 code: data.query,
                 lat: "None",
                 lon: "None",
-                issue: data.issue
+                issue: data.issue,
+                tags: "-",
             });
             return [
                 "Toilet code: " + toilet.code,
@@ -317,7 +319,7 @@ go.app = function() {
                 "Toilet longitude: " + toilet.lon,
                 // For custom issues, toilet.issue is just a string
                 "Issue: " + toilet.issue,
-                "Tags: " + (snappy_conf.tags || "-"),
+                "Tags: " + toilet.tags,
             ].join('\n');
         };
 

--- a/go-app.js
+++ b/go-app.js
@@ -299,7 +299,7 @@ go.app = function() {
             };
         };
 
-        var create_issue_message = function(data) {
+        var create_issue_message = function(snappy_conf, data) {
             toilet = _.defaults({
                 code: data.toilet.code,
                 lat: data.toilet.lat,
@@ -316,7 +316,9 @@ go.app = function() {
                 "Toilet latitude: " + toilet.lat,
                 "Toilet longitude: " + toilet.lon,
                 // For custom issues, toilet.issue is just a string
-                "Issue: " + toilet.issue].join('\n');
+                "Issue: " + toilet.issue,
+                "Tags: " + (snappy_conf.tags || "-"),
+            ].join('\n');
         };
 
         self.states.add('states:send-report', function(name, data) {
@@ -345,7 +347,7 @@ go.app = function() {
                             contact_key: self.contact.key,
                             msisdn: self.im.user.addr,
                             conversation: snappy_conf.conversation,
-                            message: create_issue_message(data)
+                            message: create_issue_message(snappy_conf, data)
                         }
                     });
                 })

--- a/src/app.js
+++ b/src/app.js
@@ -297,12 +297,14 @@ go.app = function() {
                 code: data.toilet.code,
                 lat: data.toilet.lat,
                 lon: data.toilet.lon,
-                issue: data.issue.value
+                issue: data.issue.value,
+                tags: snappy_conf.tags,
             }, {
                 code: data.query,
                 lat: "None",
                 lon: "None",
-                issue: data.issue
+                issue: data.issue,
+                tags: "-",
             });
             return [
                 "Toilet code: " + toilet.code,
@@ -310,7 +312,7 @@ go.app = function() {
                 "Toilet longitude: " + toilet.lon,
                 // For custom issues, toilet.issue is just a string
                 "Issue: " + toilet.issue,
-                "Tags: " + (snappy_conf.tags || "-"),
+                "Tags: " + toilet.tags,
             ].join('\n');
         };
 

--- a/src/app.js
+++ b/src/app.js
@@ -292,7 +292,7 @@ go.app = function() {
             };
         };
 
-        var create_issue_message = function(data) {
+        var create_issue_message = function(snappy_conf, data) {
             toilet = _.defaults({
                 code: data.toilet.code,
                 lat: data.toilet.lat,
@@ -309,7 +309,9 @@ go.app = function() {
                 "Toilet latitude: " + toilet.lat,
                 "Toilet longitude: " + toilet.lon,
                 // For custom issues, toilet.issue is just a string
-                "Issue: " + toilet.issue].join('\n');
+                "Issue: " + toilet.issue,
+                "Tags: " + (snappy_conf.tags || "-"),
+            ].join('\n');
         };
 
         self.states.add('states:send-report', function(name, data) {
@@ -338,7 +340,7 @@ go.app = function() {
                             contact_key: self.contact.key,
                             msisdn: self.im.user.addr,
                             conversation: snappy_conf.conversation,
-                            message: create_issue_message(data)
+                            message: create_issue_message(snappy_conf, data)
                         }
                     });
                 })

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -605,7 +605,8 @@ describe("App", function() {
                         "conversation":"/api/v1/snappybouncer/conversation/1/",
                         "message":
                             "Toilet code: MN34\nToilet latitude: -34.01667\n" +
-                            "Toilet longitude: -18.66404\nIssue: broken_toilet"
+                            "Toilet longitude: -18.66404\nIssue: broken_toilet\n" +
+                            "Tags: -"
                     });
                 })
                 .run();
@@ -814,7 +815,7 @@ describe("App", function() {
                         "conversation":"/api/v1/snappybouncer/conversation/1/",
                         "message":"Toilet code: MN34\nToilet latitude:" +
                             " -34.01667\nToilet longitude: -18.66404\n" +
-                            "Issue: Custom issue"
+                            "Issue: Custom issue\nTags: -"
                     });
                 })
                 .run();

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -654,6 +654,34 @@ describe("App", function() {
                 .run();
         });
 
+        it("should include the custom tags in the mesage to snappy", function() {
+            return tester
+                .setup.user.lang('en')
+                .setup.user.addr('+12345')
+                .setup(function(api) {
+                    api.config.app.snappy.tags = "@foo @bar";
+                    api.contacts.add({
+                        msisdn: '+12345',
+                        key: '34f1343f-fb98-41a1-20b1-b7d9e45e99d2'
+                    });
+                })
+                .inputs("MN34", "1")
+                .check(function(api, im , app) {
+                    var http_sent = _.where(api.http.requests, {
+                        url: 'http://besnappy.com/api/'
+                    })[0];
+                    assert.deepEqual(http_sent.data, {
+                        "contact_key":"34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
+                        "msisdn": "+12345",
+                        "conversation":"/api/v1/snappybouncer/conversation/1/",
+                        "message":"Toilet code: MN34\nToilet latitude:" +
+                            " -34.01667\nToilet longitude: -18.66404\n" +
+                            "Issue: broken_toilet\nTags: @foo @bar"
+                    });
+                })
+                .run();
+        });
+
         it("should send the information to Ona", function() {
             return tester
                 .setup.user.lang('en')

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -198,6 +198,24 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
+                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nTags: @foo @bar"
+            }
+        },
+        "response": {
+            "code": 200,
+            "data": {
+                "status": "OK"
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "url": "http://besnappy.com/api/",
+            "data": {
+                "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
+                "msisdn": "+12345",
+                "conversation": "/api/v1/snappybouncer/conversation/1/",
                 "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Custom issue\nTags: -"
             }
         },

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -180,7 +180,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet"
+                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nTags: -"
             }
         },
         "response": {
@@ -198,7 +198,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Custom issue"
+                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Custom issue\nTags: -"
             }
         },
         "response": {
@@ -216,7 +216,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Error issue"
+                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Error issue\nTags: -"
             }
         },
         "response": {


### PR DESCRIPTION
A proper implementation requires westerncapelabs/django-snappy-vumi-bouncer#7, but we can at least add them to the message for now which allows them to be picked up with a Snappy trigger.
