### PR TITLE
add timestamp to snappy submission

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -330,7 +330,6 @@ go.app = function() {
                 issue: data.issue.value,
                 lang: self.im.user.lang,
                 tags: snappy_conf.tags,
-                timestamp: self.now(),
             }, {
                 code: data.query,
                 lat: "None",
@@ -347,7 +346,7 @@ go.app = function() {
                 "Issue: " + toilet.issue,
                 "Language: " + toilet.lang,
                 "Tags: " + toilet.tags,
-                "Timestamp: " + toilet.timestamp,
+                "Timestamp: " + self.now(),
             ].join('\n');
         };
 

--- a/go-app.js
+++ b/go-app.js
@@ -330,6 +330,7 @@ go.app = function() {
                 issue: data.issue.value,
                 lang: self.im.user.lang,
                 tags: snappy_conf.tags,
+                timestamp: self.now(),
             }, {
                 code: data.query,
                 lat: "None",
@@ -346,6 +347,7 @@ go.app = function() {
                 "Issue: " + toilet.issue,
                 "Language: " + toilet.lang,
                 "Tags: " + toilet.tags,
+                "Timestamp: " + toilet.timestamp,
             ].join('\n');
         };
 

--- a/src/app.js
+++ b/src/app.js
@@ -323,7 +323,6 @@ go.app = function() {
                 issue: data.issue.value,
                 lang: self.im.user.lang,
                 tags: snappy_conf.tags,
-                timestamp: self.now(),
             }, {
                 code: data.query,
                 lat: "None",
@@ -340,7 +339,7 @@ go.app = function() {
                 "Issue: " + toilet.issue,
                 "Language: " + toilet.lang,
                 "Tags: " + toilet.tags,
-                "Timestamp: " + toilet.timestamp,
+                "Timestamp: " + self.now(),
             ].join('\n');
         };
 

--- a/src/app.js
+++ b/src/app.js
@@ -323,6 +323,7 @@ go.app = function() {
                 issue: data.issue.value,
                 lang: self.im.user.lang,
                 tags: snappy_conf.tags,
+                timestamp: self.now(),
             }, {
                 code: data.query,
                 lat: "None",
@@ -339,6 +340,7 @@ go.app = function() {
                 "Issue: " + toilet.issue,
                 "Language: " + toilet.lang,
                 "Tags: " + toilet.tags,
+                "Timestamp: " + toilet.timestamp,
             ].join('\n');
         };
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -611,7 +611,8 @@ describe("App", function() {
                             "Toilet code: MN34\nToilet latitude: -34.01667\n" +
                             "Toilet longitude: -18.66404\nIssue: broken_toilet\n" +
                             "Language: en\n" +
-                            "Tags: -"
+                            "Tags: -\n" +
+                            "Timestamp: 1970-01-01T02:00:01+02:00"
                     });
                 })
                 .run();
@@ -640,7 +641,8 @@ describe("App", function() {
                             "Toilet code: MN34\nToilet latitude: -34.01667\n" +
                             "Toilet longitude: -18.66404\nIssue: broken_toilet\n" +
                             "Language: xh\n" +
-                            "Tags: -"
+                            "Tags: -\n" +
+                            "Timestamp: 1970-01-01T02:00:01+02:00"
                     });
                 })
                 .run();
@@ -688,7 +690,7 @@ describe("App", function() {
                 .run();
         });
 
-        it("should include the custom tags in the mesage to snappy", function() {
+        it("should include the custom tags in the message to snappy", function() {
             return tester
                 .setup.user.lang('en')
                 .setup.user.addr('+12345')
@@ -708,9 +710,14 @@ describe("App", function() {
                         "contact_key":"34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                         "msisdn": "+12345",
                         "conversation":"/api/v1/snappybouncer/conversation/1/",
-                        "message":"Toilet code: MN34\nToilet latitude:" +
-                            " -34.01667\nToilet longitude: -18.66404\n" +
-                            "Issue: broken_toilet\nLanguage: en\nTags: @foo @bar"
+                        "message":
+                            "Toilet code: MN34\n" +
+                            "Toilet latitude: -34.01667\n" +
+                            "Toilet longitude: -18.66404\n" +
+                            "Issue: broken_toilet\n" +
+                            "Language: en\n" +
+                            "Tags: @foo @bar\n" +
+                            "Timestamp: 1970-01-01T02:00:01+02:00"
                     });
                 })
                 .run();
@@ -877,9 +884,14 @@ describe("App", function() {
                         "contact_key":"34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                         "msisdn": "+12345",
                         "conversation":"/api/v1/snappybouncer/conversation/1/",
-                        "message":"Toilet code: MN34\nToilet latitude:" +
-                            " -34.01667\nToilet longitude: -18.66404\n" +
-                            "Issue: Custom issue\nLanguage: en\nTags: -"
+                        "message":
+                            "Toilet code: MN34\n" +
+                            "Toilet latitude: -34.01667\n" +
+                            "Toilet longitude: -18.66404\n" +
+                            "Issue: Custom issue\n" +
+                            "Language: en\n" +
+                            "Tags: -\n" +
+                            "Timestamp: 1970-01-01T02:00:01+02:00"
                     });
                 })
                 .run();

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -188,7 +188,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nLanguage: en\nTags: -"
+                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nLanguage: en\nTags: -\nTimestamp: 1970-01-01T02:00:01+02:00"
             }
         },
         "response": {
@@ -206,7 +206,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nLanguage: xh\nTags: -"
+                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nLanguage: xh\nTags: -\nTimestamp: 1970-01-01T02:00:01+02:00"
             }
         },
         "response": {
@@ -224,7 +224,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nLanguage: en\nTags: @foo @bar"
+                "message": "Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: broken_toilet\nLanguage: en\nTags: @foo @bar\nTimestamp: 1970-01-01T02:00:01+02:00"
             }
         },
         "response": {
@@ -242,7 +242,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Custom issue\nLanguage: en\nTags: -"
+                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Custom issue\nLanguage: en\nTags: -\nTimestamp: 1970-01-01T02:00:01+02:00"
             }
         },
         "response": {
@@ -260,7 +260,7 @@ module.exports = function() {
                 "contact_key": "34f1343f-fb98-41a1-20b1-b7d9e45e99d2",
                 "msisdn": "+12345",
                 "conversation": "/api/v1/snappybouncer/conversation/1/",
-                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Error issue\nLanguage: en\nTags: -"
+                "message":"Toilet code: MN34\nToilet latitude: -34.01667\nToilet longitude: -18.66404\nIssue: Error issue\nLanguage: en\nTags: -\nTimestamp: 1970-01-01T02:00:01+02:00"
             }
         },
         "response": {


### PR DESCRIPTION
Snappy has an issue with identical messages, so if the same person submits two identical reports, the second report is rejected. To correct this we will add a timestamp to the message body to ensure that every submission is different.
